### PR TITLE
markerがundefinedのときのみリセット

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -142,7 +142,9 @@ function kyoikuto() {
 
     var onChangeHandler = function () {
       calculateAndDisplayRoute(directionsService, directionsRenderer);
-      marker.setMap(null);
+      if(marker){
+        marker.setMap(null);
+      }
       var end = document.getElementById('end').value;
       if(end == "全学教育棟本館"){
       marker = new google.maps.Marker({


### PR DESCRIPTION
markerがundefinedだったときに`marker.setMap(null);`を呼び出さないように修正しました。

以下の手順で動作確認済みです
1. search.htmlを開く
2. 全学教育棟本館を選択し、検索ボタンを押下。全学教育棟本館へのルーティングと建物内表示のマーカーの表示を確認。
3. 全学教育棟A館を選択し、検索ボタンを押下。全学教育棟A館へのルーティングと建物内表示のマーカーの表示を確認。全学教育棟本館のマーカーは表示されていない。

確認をお願いします。
